### PR TITLE
feat(adr-tools): add file to configure adr-tools

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/decisions


### PR DESCRIPTION
The [adr-tools](https://github.com/npryce/adr-tools/tree/master) when initalized creates a file to configure itself. Since the project isn't using the default path this is required for adr-tools to work without needing to recreate the file on the development machines.
